### PR TITLE
Correct typo in Operators table

### DIFF
--- a/_docs/c-advanced/expressions.html
+++ b/_docs/c-advanced/expressions.html
@@ -20,7 +20,6 @@ order: 1
       </thead>
       <tbody>
         <tr>
-          <td>(3/2)</td>
           <td>+</td>
           <td>Addition operator</td>
           <td>(3+2)</td>


### PR DESCRIPTION
Removed errant <td>(3/2)</td> tag for addition operator.