### PR TITLE
No "!" after constant names

### DIFF
--- a/_docs/c-advanced/expressions.html
+++ b/_docs/c-advanced/expressions.html
@@ -59,12 +59,12 @@ order: 1
       <tbody>
         <tr>
           <td>pi</td>
-          <td>Value of Pi!</td>
+          <td>Value of pi</td>
           <td>(pi)</td>
           <td>3.141592653589793</td>
         </tr><tr>
           <td>e</td>
-          <td>Value of E!</td>
+          <td>Value of e</td>
           <td>(e)</td>
           <td>2.718281828459045</td>
         </tr><!-- end ngRepeat: constant in mathConstants -->


### PR DESCRIPTION
Removed "!" after Pi and e constant names. There is no need to show excitement there, and even worse it looks like the factorial operator. Also e should never be uppercase when talking about the mathematical constant.