### PR TITLE
Examples for ceil and floor functions are incorrect.

### DIFF
--- a/_docs/c-advanced/expressions.html
+++ b/_docs/c-advanced/expressions.html
@@ -170,14 +170,14 @@ order: 1
         <tr>
           <td>ceil(number)</td>
           <td>Ceiling function (gets the next highest integer)</td>
-          <td>(pi)</td>
-          <td>3.141592653589793</td>
+          <td>(ceil(1.2))</td>
+          <td>2</td>
         </tr>
         <tr>
           <td>floor(number)</td>
           <td>Floor function - gets the next lowest integer)</td>
-          <td>(pi)</td>
-          <td>3.141592653589793</td>
+          <td>(floor(1.6))</td>
+          <td>1</td>
         </tr>
         <tr>
           <td>log(number)</td>


### PR DESCRIPTION
They show examples for pi. Code change proposes appropriate examples.